### PR TITLE
webpack（ビルドスクリプト）に関する修正リクエスト

### DIFF
--- a/public/controller.html
+++ b/public/controller.html
@@ -45,7 +45,7 @@
 
 		<div id="rightArea" class="rightArea">
 			<p class="content_id">
-				<span id="content_id_label">Content ID：</span><span id="content_id" >No Content Selected.</span>
+				<span id="content_id_label">Content ID：</span><span id="content_id" class="content_id_text">No Content Selected.</span>
 			</p>
 			<p class="controller_id">
 				<span id="controller_id_label">Contoller ID：</span><span id="controller_id" >No Content Selected.</span>

--- a/public/src/css/controller.css
+++ b/public/src/css/controller.css
@@ -1001,3 +1001,7 @@ p {
 .copyright_link:hover {
 	color : lightgray;
 }
+/* DisplayID選択可 */
+.content_id_text{
+	user-select: text;
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -4,7 +4,8 @@ const webpack = require('webpack');
 var NodeTargetPlugin = require('webpack/lib/node/NodeTargetPlugin')
 var ExternalsPlugin = webpack.ExternalsPlugin
 
-const DEBUG = !process.argv.includes('--release');
+const DEBUG = process.argv.includes('--mode=development');
+console.log("DEBUG=", DEBUG);
 
 module.exports = {
     // モードの設定、v4系以降はmodeを指定しないと、webpack実行時に警告が出る
@@ -32,7 +33,15 @@ module.exports = {
             // CSSを読み込むローダー
             {
                 test: /\.css$/,
-                use: ['style-loader', 'css-loader'], // `-loader`は省略可能
+                use: [
+                    'style-loader', // スタイルをDOMに挿入
+                    {
+                        loader: 'css-loader',
+                        options: {
+                            sourceMap: DEBUG, // ソースマップを有効化
+                        },
+                    },
+                ],
             },
             // ファイルを読み込むローダー
             {
@@ -53,7 +62,7 @@ module.exports = {
             }
         ],
     },
-    devtool: DEBUG ? 'inline-source-map' : false,
+    devtool: DEBUG ? 'source-map' : false, // ソースマップを生成する
     // webpack-dev-serverの設定
     devServer: {
         contentBase: path.join(__dirname, 'public'),


### PR DESCRIPTION
１．webpackで気になった箇所を修正しました。

・webpackのコマンドライン引数で受け付けている”--release”が渡される方法が不明でした。
常にDebugビルドになっているように見えます。現状に合わせて`npm run watch`の時はデバッグビルド、`npm run webpack` or `npm run install`の時は通常ビルドになるようにしました。

・soucemapを有効にする設定が正しく機能していないようだったので修正しました。chromeでは正しくなりましたが、edgeでは元のコードが見える状態になっていてsoucemap確認はchromeブラウザで確認できるようになります。

soucemapは、開発者ツールで元のソースがどのファイルか表すもので、コメントで書く方法もありますが、webpackで自動生成していたのでその機能が動くように修正しました。

コメントでsoucemapを記述する方法

```
//# sourceURL=（ソースコードのURL）
```

参考：
https://www.w2solution.co.jp/corporate/tech/%E3%82%A4%E3%83%B3%E3%83%A9%E3%82%A4%E3%83%B3%E3%82%B9%E3%82%AF%E3%83%AA%E3%83%97%E3%83%88%E3%82%92%E3%83%87%E3%83%90%E3%83%83%E3%82%B0%E3%81%97%E3%81%A6%E3%81%BF%E3%82%88%E3%81%86%EF%BC%81/

上：DEBUG= false `npm run watch` デバッグビルド
下：DEBUG= true `npm run webpack` productionビルド

![image](https://github.com/user-attachments/assets/bd6484df-0251-4db3-b4a4-aa0b67e7e729)

２．controllerの画面でdisplayのIDのコピーに難があったので選択できるようにスタイルを追加しました。

IDのところをダブルクリックすると反転しますので、この状態でctrl+cするとクリップボードに入ります。。
![image](https://github.com/user-attachments/assets/85406be5-dc6f-49f0-afad-91abac2b7583)





